### PR TITLE
Add deleting txt files on exiting app.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.exe
 *.TXT
+/.vs/ProjectSettings.json
+/.vs

--- a/AppMenu.cs
+++ b/AppMenu.cs
@@ -134,7 +134,7 @@ namespace MaxSuperHiperMegaRambo5
             int len = fileReaded.Length;
             return len;
         }
-        static int Exit()
+        static void Exit()
         {
             if (File.Exists("6.txt"))
             {

--- a/AppMenu.cs
+++ b/AppMenu.cs
@@ -112,6 +112,7 @@ namespace MaxSuperHiperMegaRambo5
                         }
                     case 8:
                         {
+                            Exit();
                             Console.WriteLine("Program terminated");
                             Thread.Sleep(1280);
                             break;
@@ -133,6 +134,18 @@ namespace MaxSuperHiperMegaRambo5
             int len = fileReaded.Length;
             return len;
         }
+        static int Exit()
+        {
+            if (File.Exists("6.txt"))
+            {
+                File.Delete("6.txt");
+            }
+            if (File.Exists("statystyki.txt"))
+            {
+                File.Delete("statystyki.txt");
+            }
+        }
+
 
 
         static public void Main(String[] args)


### PR DESCRIPTION
Bounds function 8 on the menu to exit, which breaks the loop and removes both text files, the text one, and one with statistics.
resolves #9 

- by Maciej Karczewski